### PR TITLE
Feat(components):add generating allOf/oneOf

### DIFF
--- a/client/components/SchemaObj.vue
+++ b/client/components/SchemaObj.vue
@@ -12,7 +12,7 @@
           <td style="width: 5px;">:</td>
           <td style="width: calc(100% - 95px);">
             <div v-if="!obj.hasNest">"{{ obj.type }}"</div>
-            <div v-if="obj.hasNest">
+            <div v-else>
               <schema-obj :schema-obj="obj.schemaObj" class="nest" />
             </div>
           </td>

--- a/client/components/SchemaObj.vue
+++ b/client/components/SchemaObj.vue
@@ -62,7 +62,6 @@ export default {
   methods: {
     existsOf(obj) {
       return 'oneOf' in obj || 'anyOf' in obj
-      // return 'allOf' in obj || 'oneOf' in obj || 'anyOf' in obj
     },
     isArray(obj) {
       return obj === 'array'

--- a/client/components/SchemaObj.vue
+++ b/client/components/SchemaObj.vue
@@ -54,6 +54,8 @@ export default {
           : this.getProperties(obj.items)
       } else if ('allOf' in obj) {
         return this.mergeAllOf(obj.allOf)
+      } else if ('oneOf' in obj) {
+        return this.mergeOneOf(obj.oneOf)
       } else {
         return this.dummyArr
       }
@@ -61,7 +63,7 @@ export default {
   },
   methods: {
     existsOf(obj) {
-      return 'oneOf' in obj || 'anyOf' in obj
+      return 'anyOf' in obj
     },
     isArray(obj) {
       return obj === 'array'
@@ -86,6 +88,18 @@ export default {
     mergeAllOf(arr) {
       const properties = arr.flatMap((obj) => {
         return this.getProperties(obj)
+      })
+      return properties
+    },
+    mergeOneOf(arr) {
+      const properties = arr.map((obj) => {
+        return {
+          name: 'oneOf',
+          required: false,
+          type: 'oneOf',
+          hasNest: true,
+          schemaObj: obj
+        }
       })
       return properties
     }

--- a/client/components/SchemaObj.vue
+++ b/client/components/SchemaObj.vue
@@ -58,7 +58,7 @@ export default {
       }
       if ('items' in obj) {
         return 'allOf' in obj.items || 'oneOf' in obj.items
-          ? this.judgeFuncAndObject(obj.items.allOf || obj.item.oneOf)
+          ? this.judgeFuncAndObject(obj.items)
           : this.getProperties(obj.items)
       }
       if ('allOf' in obj) {

--- a/client/components/SchemaObj.vue
+++ b/client/components/SchemaObj.vue
@@ -45,28 +45,29 @@ export default {
   },
   computed: {
     objectsToShow() {
-      const obj = this.schemaObj
-      if ('properties' in obj) {
-        return this.getProperties(obj)
-      } else if ('items' in obj) {
-        return 'allOf' in obj.items
-          ? this.mergeAllOf(obj.items.allOf)
-          : this.getProperties(obj.items)
-      } else if ('allOf' in obj) {
-        return this.mergeAllOf(obj.allOf)
-      } else if ('oneOf' in obj) {
-        return this.mergeOneOf(obj.oneOf)
-      } else {
-        return this.dummyArr
-      }
+      return this.judgeFuncAndObject(this.schemaObj)
     }
   },
   methods: {
-    existsOf(obj) {
-      return 'anyOf' in obj
-    },
     isArray(obj) {
       return obj === 'array'
+    },
+    judgeFuncAndObject(obj) {
+      if ('properties' in obj) {
+        return this.getProperties(obj)
+      }
+      if ('items' in obj) {
+        return 'allOf' in obj.items || 'oneOf' in obj.items
+          ? this.judgeFuncAndObject(obj.items.allOf || obj.item.oneOf)
+          : this.getProperties(obj.items)
+      }
+      if ('allOf' in obj) {
+        return this.mergeAllOf(obj.allOf)
+      }
+      if ('oneOf' in obj) {
+        return this.mergeOneOf(obj.oneOf)
+      }
+      return this.dummyArr
     },
     getProperties(obj) {
       const setProperties = (obj) => {

--- a/client/components/SchemaObj.vue
+++ b/client/components/SchemaObj.vue
@@ -54,7 +54,9 @@ export default {
     },
     judgeFuncAndObject(obj) {
       if ('properties' in obj) {
-        return this.getProperties(obj)
+        return 'allOf' in obj.properties || 'oneOf' in obj.properties
+          ? this.judgeFuncAndObject(obj)
+          : this.getProperties(obj)
       }
       if ('items' in obj) {
         return 'allOf' in obj.items || 'oneOf' in obj.items
@@ -86,13 +88,12 @@ export default {
       return 'properties' in obj ? setProperties(obj) : obj
     },
     mergeAllOf(arr) {
-      const properties = arr.flatMap((obj) => {
+      return arr.flatMap((obj) => {
         return this.getProperties(obj)
       })
-      return properties
     },
     mergeOneOf(arr) {
-      const properties = arr.map((obj) => {
+      return arr.map((obj) => {
         return {
           name: 'oneOf',
           required: false,
@@ -101,7 +102,6 @@ export default {
           schemaObj: obj
         }
       })
-      return properties
     }
   }
 }


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->

Issue Number: N/A

<!--- Describe your changes in detail. -->
allOf/oneOfを表示させるためのmethods等を追加しました。
 

1. 新15行目　v-ifの条件変更
allOf/oneOfの追加対応をしたことで、hasOfによる除外判定が不要となったため削除。

2. 新43行目   dummy値の変更
新15行目(1)の対応に合わせて、dummy値を変更。

3. 新55行目　judgeFuncAndObjectの追加
旧48行目〜54行目に記載していた条件をjudgeFuncAndObjectとしてmethodsに追加。
新61行目部分で再帰的に利用する記述があったため、methodsとして外出しをしているが、computedの中の記述でもよいかもしれない。

SchemaObject直下にallOf/oneOfを持つことが可能であるため、想定しうる組み合わせとしては下記の通り。
```
#case1 
allOf :SchemaObject[]

#case2
properties :string|SchemaObject[] {
  allOf :SchemaObject[]
}

#case3
items :SchemaObject {
  allOf :SchemaObject[]
}

```

4. 旧74行目 getPropertiesの値削除
新15行目の対応に合わせて、dummy値を変更。

5. 新88行目　条件文の変更
新15行目(1)の対応に合わせて、dummy値を変更。

6. 新90行目 mergeAllOfの追加

7. 新95行目 mergeOneOfの追加
UI案がないため、暫定でnameにoneOfであることを明示。

