### PR TITLE
[Issue #46] Bug Fix: Fix select and text components style inside of table tag

### DIFF
--- a/client/components/ApiMethod.vue
+++ b/client/components/ApiMethod.vue
@@ -139,6 +139,7 @@ export default {
 table {
   font-size: 13px;
   table-layout: fixed;
+  border-collapse: collapse;
 }
 p {
   margin: 0;

--- a/client/components/ApiParameters.vue
+++ b/client/components/ApiParameters.vue
@@ -72,6 +72,7 @@ export default {
 table {
   font-size: 13px;
   table-layout: fixed;
+  border-collapse: collapse;
 }
 p {
   margin: 0;

--- a/client/components/ApiResponse.vue
+++ b/client/components/ApiResponse.vue
@@ -60,7 +60,4 @@ export default {
 p {
   margin: 0;
 }
-table {
-  border-collapse: collapse;
-}
 </style>

--- a/client/components/ApiResponse.vue
+++ b/client/components/ApiResponse.vue
@@ -60,4 +60,7 @@ export default {
 p {
   margin: 0;
 }
+table {
+  border-collapse: collapse;
+}
 </style>


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description
該当の`<v-text-field>`や`<v-select>`が`<table>`で囲まれていて、デフォルトで`border-collapse: separate;`が設定されていたため、`<legend>`部分に隙間が空いて見えていたようです。

<!-- link to a relevant issue. -->

Issue Number: #46 

<!--- Describe your changes in detail. -->
