### PR TITLE
Bug Fix: Number of hits overwraps with Pagination when windows width is narrow

### DIFF
--- a/client/pages/search.vue
+++ b/client/pages/search.vue
@@ -11,11 +11,13 @@
         <div class="number-of-hits">
           <span>{{ filterdApiList.length }}</span> apis found
         </div>
-        <Pagination
-          :num="filterdApiList.length"
-          :page="pageNumber"
-          @input="onReceivePage"
-        />
+        <div class="pagination-wrapper">
+          <Pagination
+            :num="filterdApiList.length"
+            :page="pageNumber"
+            @input="onReceivePage"
+          />
+        </div>
       </div>
       <div class="search-result-body">
         <div
@@ -133,11 +135,18 @@ export default class extends Vue {
 }
 
 .search-result-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 15px;
 }
 
+.pagination-wrapper {
+  width: 400px;
+}
+
 .number-of-hits {
-  margin-bottom: -35px;
   font-size: 13pt;
   font-weight: 500;
 }

--- a/client/pages/search.vue
+++ b/client/pages/search.vue
@@ -143,7 +143,8 @@ export default class extends Vue {
 }
 
 .pagination-wrapper {
-  width: 400px;
+  width: 100%;
+  max-width: 400px;
 }
 
 .number-of-hits {


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description
flexboxでwindowの幅が狭い場合は2行になるようにしました。
また、`pagination-wrapper`に`width`を定めて、`pagination`の数が減ったり増えたりしても正しい数で表示されるようにしました。

<img width="643" alt="Screen Shot 0002-03-20 at 12 52 00" src="https://user-images.githubusercontent.com/42709317/77134281-9af53580-6aa9-11ea-8a21-329498281544.png">


<!-- link to a relevant issue. -->

Issue Number: N/A

<!--- Describe your changes in detail. -->
